### PR TITLE
Microsoft Edge (EdgeHTML) links to english wikipedia

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -482,7 +482,7 @@
     "dateClose": "2021-03-09",
     "dateOpen": "2015-04-29",
     "description": "Microsoft Edge is a cross-platform web browser and it is the successor of Internet Explorer.",
-    "link": "https://it.wikipedia.org/wiki/Microsoft_Edge",
+    "link": "https://en.wikipedia.org/wiki/Microsoft_Edge",
     "name": "Microsoft Edge (EdgeHTML)",
     "type": "app"
   },


### PR DESCRIPTION
Microsoft Edge (EdgeHTML) used to link to the italian wikipedia page. This PR links properly to the english Wikipedia site like other entries.